### PR TITLE
Align client.go with extension-provider-hcloud

### DIFF
--- a/pkg/hcloud/apis/client.go
+++ b/pkg/hcloud/apis/client.go
@@ -19,6 +19,7 @@ package apis
 
 import (
 	"github.com/hetznercloud/hcloud-go/hcloud"
+	"strings"
 )
 
 var singletons = make(map[string]*hcloud.Client)
@@ -28,6 +29,11 @@ var singletons = make(map[string]*hcloud.Client)
 // PARAMETERS
 // token string Token to look up client instance for
 func GetClientForToken(token string) *hcloud.Client {
+	// if one accidentially copies a newline character into the token, remove it!
+	if strings.Contains(token, "\n") {
+		token = strings.Replace(token, "\n", "", -1)
+	}
+
 	client, ok := singletons[token]
 
 	if !ok {


### PR DESCRIPTION
Signed-off-by: Jens Schneider <schneider@23technologies.cloud>

**What this PR does / why we need it**:
Replaces newline characters in the bearer token.  This is needed, as the token is printed in clear text, if it contains a newline character at the end, which is a common error.
