### PR TITLE
Get the server by name in case the providerID is missing

### DIFF
--- a/pkg/hcloud/machine_controller_test.go
+++ b/pkg/hcloud/machine_controller_test.go
@@ -219,8 +219,7 @@ var _ = Describe("MachineController", func() {
 					},
 				},
 				expect: expect{
-					errToHaveOccurred: true,
-					errStatus: codes.InvalidArgument,
+					errToHaveOccurred: false,
 				},
 			}),
 			Entry("contains an invalid provider ID", &data{


### PR DESCRIPTION
Signed-off-by: Jens Schneider <schneider@23technologies.cloud>

-------

**What this PR does / why we need it**:
In certain circumstances we cannot delete machines due to missing providerIDs.
In this case the machine will be deleted by name from now on. 

**Which issue(s) this PR fixes**:
Fixes #6

**Special notes for your reviewer**:
Once the PR is approved and merged, we need to include the new mcm image in the gardener-extension-provider-hcloud.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
NONE
```