### PR TITLE
Fix machines remaining in CrashLoopBackOff

### DIFF
--- a/pkg/hcloud/machine_controller.go
+++ b/pkg/hcloud/machine_controller.go
@@ -325,11 +325,14 @@ func (p *MachineProvider) createMachineOnErrorCleanup(ctx context.Context, req *
 	client := apis.GetClientForToken(string(req.Secret.Data["token"]))
 	resultData := ctx.Value(CtxWrapDataKey("MethodData")).(*CreateMachineMethodData)
 
+  server := &hcloud.Server{}
 	if resultData.ServerID != 0 {
-		server, _, _ := client.Server.GetByID(ctx, resultData.ServerID)
-		if nil != server {
+		server, _, _ = client.Server.GetByID(ctx, resultData.ServerID)
+	} else {
+		server, _, _ = client.Server.GetByName(ctx, req.Machine.Name)
+	}
+	if nil != server {
 			_, _ = client.Server.Delete(ctx, server)
-		}
 	}
 
 	if resultData.FloatingIPID != 0 {

--- a/pkg/hcloud/machine_controller.go
+++ b/pkg/hcloud/machine_controller.go
@@ -417,6 +417,7 @@ func (p *MachineProvider) GetMachineStatus(ctx context.Context, req *driver.GetM
 		err      error
 		machine  = req.Machine
 		secret   = req.Secret
+		machineClass = req.MachineClass
 		server   *hcloud.Server
 		serverID int
 	)
@@ -424,6 +425,11 @@ func (p *MachineProvider) GetMachineStatus(ctx context.Context, req *driver.GetM
 	// Log messages to track start and end of request
 	klog.V(2).Infof("Get request has been received for %q", machine.Name)
 	defer klog.V(2).Infof("Machine get request has been processed successfully for %q", machine.Name)
+
+	providerSpec, err := transcoder.DecodeProviderSpecFromMachineClass(machineClass, secret)
+	if nil != err {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	client := apis.GetClientForToken(string(secret.Data["token"]))
 
@@ -451,7 +457,8 @@ func (p *MachineProvider) GetMachineStatus(ctx context.Context, req *driver.GetM
 		return nil, status.Error(codes.NotFound, fmt.Sprintf("VM %s (%d) does not exist", machine.Name, serverID))
 	}
 
-	return &driver.GetMachineStatusResponse{ ProviderID: machine.Spec.ProviderID, NodeName: server.Name }, nil
+	providerID := transcoder.EncodeProviderID(providerSpec.Zone, serverID)
+	return &driver.GetMachineStatusResponse{ ProviderID: providerID, NodeName: server.Name }, nil
 }
 
 // ListMachines lists all the machines possibilly created by a providerSpec

--- a/pkg/hcloud/machine_controller.go
+++ b/pkg/hcloud/machine_controller.go
@@ -167,7 +167,7 @@ func (p *MachineProvider) createMachine(ctx context.Context, req *driver.CreateM
 
 	server, err = apis.WaitForActionsAndGetServer(ctx, client, serverResult.Server)
 	if nil != err {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(codes.Unknown, err.Error())
 	}
 
 	if "" != providerSpec.PlacementGroupID {
@@ -188,7 +188,7 @@ func (p *MachineProvider) createMachine(ctx context.Context, req *driver.CreateM
 
 		server, err = apis.WaitForActionsAndGetServer(ctx, client, serverResult.Server)
 		if nil != err {
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, status.Error(codes.Unknown, err.Error())
 		}
 	}
 
@@ -232,7 +232,7 @@ func (p *MachineProvider) createMachine(ctx context.Context, req *driver.CreateM
 
 	server, err = apis.WaitForActionsAndGetServer(ctx, client, serverResult.Server)
 	if nil != err {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(codes.Unknown, err.Error())
 	}
 
 	// Compare running results with expectation


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes we run in the situation that a machine is not created just in time on the hcloud. In these cases, machines will be stuck in the CrashLoopBackOff phase. In manual tests, I was able to reproduce the issue and fix it with the proposed changes.

**Which issue(s) this PR fixes**:
Fixes #8

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
Machines should not be stuck in the CrashLoopBackOff phase anymore
```