### PR TITLE
Make hcloud endpoint changeable

### DIFF
--- a/pkg/hcloud/apis/client.go
+++ b/pkg/hcloud/apis/client.go
@@ -43,6 +43,7 @@ func GetClientForToken(token string) *hcloud.Client {
 	if !ok {
 		opts := []hcloud.ClientOption{
 			hcloud.WithToken(token),
+			hcloud.WithApplication("machine-controller-manager-provider-hcloud", "v0.0.0")
 		}
 		if endpoint := os.Getenv("HCLOUD_ENDPOINT"); endpoint != "" {
 			opts = append(opts, hcloud.WithEndpoint(endpoint))

--- a/pkg/hcloud/apis/client.go
+++ b/pkg/hcloud/apis/client.go
@@ -18,6 +18,7 @@ limitations under the License.
 package apis
 
 import (
+	"os"
 	"strings"
 
 	"github.com/hetznercloud/hcloud-go/hcloud"
@@ -40,10 +41,16 @@ func GetClientForToken(token string) *hcloud.Client {
 	client, ok := singletons[token]
 
 	if !ok {
-		client = hcloud.NewClient(hcloud.WithToken(token))
+		opts := []hcloud.ClientOption{
+			hcloud.WithToken(token),
+		}
+		if endpoint := os.Getenv("HCLOUD_ENDPOINT"); endpoint != "" {
+			opts = append(opts, hcloud.WithEndpoint(endpoint))
+		}
+		client = hcloud.NewClient(opts...)
 	}
 
-    return client
+	return client
 }
 
 // SetClientForToken sets a preconfigured HCloud client for the given token.

--- a/pkg/hcloud/apis/client.go
+++ b/pkg/hcloud/apis/client.go
@@ -43,7 +43,7 @@ func GetClientForToken(token string) *hcloud.Client {
 	if !ok {
 		opts := []hcloud.ClientOption{
 			hcloud.WithToken(token),
-			hcloud.WithApplication("machine-controller-manager-provider-hcloud", "v0.0.0")
+			hcloud.WithApplication("machine-controller-manager-provider-hcloud", "v0.0.0"),
 		}
 		if endpoint := os.Getenv("HCLOUD_ENDPOINT"); endpoint != "" {
 			opts = append(opts, hcloud.WithEndpoint(endpoint))


### PR DESCRIPTION
Signed-off-by: Fynn Späker <spaeker@23technologies.cloud>

**What this PR does / why we need it**:
The PR enables the possibility to configure the hcloud-api endpoint.
Also, it adds the user-agent to identify the controller in the request logs


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
Its now possible to configure the hcloud-api endpoint by setting the environment variable 'HCLOUD_ENDPOINT'
```